### PR TITLE
Skip packlist.t if List::MoreUtils is a vendor-pkg...

### DIFF
--- a/README.pod
+++ b/README.pod
@@ -39,6 +39,10 @@ L<http://github.com/jberger/Module-Build-CleanInstall>
 
 Joel Berger, E<lt>joel.a.berger@gmail.comE<gt>
 
+=head1 ADDITIONAL CONTRIBUTIONS
+
+Randall Sindlinger, E<lt>rsindlin@gmail.comE<gt>
+
 =head1 COPYRIGHT AND LICENSE
 
 Copyright (C) 2012 by Joel Berger

--- a/lib/Module/Build/CleanInstall.pm
+++ b/lib/Module/Build/CleanInstall.pm
@@ -86,6 +86,10 @@ L<http://github.com/jberger/Module-Build-CleanInstall>
 
 Joel Berger, E<lt>joel.a.berger@gmail.comE<gt>
 
+=head1 ADDITIONAL CONTRIBUTIONS
+
+Randall Sindlinger, E<lt>rsindlin@gmail.comE<gt>
+
 =head1 COPYRIGHT AND LICENSE
 
 Copyright (C) 2012 by Joel Berger

--- a/t/packlist.t
+++ b/t/packlist.t
@@ -2,12 +2,32 @@ use strict;
 use warnings;
 
 use Test::More;
+use Pod::Perldoc;
+use File::Spec::Functions qw/splitpath splitdir catpath catdir/;
 
 use Module::Build::CleanInstall;
 
 # some CPANtesters use a fresh and not installed version of all dependent modules
 if (grep { m#List-MoreUtils.*?blib# } @INC) {
   plan skip_all => "Test irrelevant when not using an installed version of List::MoreUtils";
+}
+
+# In distros where List::MoreUtils is a vendor-package, there is no .packlist,
+# so ExtUtils::Installed won't see it.  Checking for this case.  If more than one is
+# installed, only looking at first result.
+my ($L_MU_path) = Pod::Perldoc->new->grand_search_init(['List::MoreUtils']);
+if ($L_MU_path) {note 'List::MoreUtils is available'};
+
+# get the _expected_ .packlist directory in a portable way (using File::Spec functions)
+my ($vol,$dir,$file) = splitpath ($L_MU_path, 1); #nofile flag
+$dir =~ s/.pm$//;
+my @dirs = (splitdir($dir));
+my @L_MU_only = splice(@dirs, -2, 2);
+my $expected_L_MU_packlist_dir = catdir(@dirs, 'auto', @L_MU_only);
+
+if (-e catpath($vol, $expected_L_MU_packlist_dir) &&
+    !-e catpath($vol, $expected_L_MU_packlist_dir, '.packlist')) {
+  plan skip_all => "Test irrelevant when using distro's vendor-package install of List::MoreUtils";
 }
 
 my $packlist = Module::Build::CleanInstall->_get_packlist('List::MoreUtils');


### PR DESCRIPTION
Many distros (eg, RedHat and Debian) provide List::MoreUtils as
a vendor-package and don't provide a packlist.  This causes the
packlist.t test to fail, interrupting many install suites.
Added logic detects such an installation (ie, an auto/List/MoreUtils
path exists under a perl @INC path, but it does not contain a
.packlist) and skips the tests.  This behaviour is analogous to
a force install, which is what is manually required currently in
this scenario.